### PR TITLE
Use comply base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# FROM strongdm/comply:latest
-FROM golang:latest
+FROM strongdm/comply:latest
+# FROM golang:latest
 
 RUN go get github.com/strongdm/comply
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM strongdm/comply:latest
 # FROM golang:latest
 
-RUN go get github.com/strongdm/comply
+# RUN go get github.com/strongdm/comply
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
- Need to run `comply build`, but the upstream approach doesn't include the dependencies such as `pandoc` and `pdflatex` so `build` target is stuck. 
- Use `strongdm/comply` as the upstream image instead.
